### PR TITLE
Do not log logging activity

### DIFF
--- a/.changeset/cold-oranges-help.md
+++ b/.changeset/cold-oranges-help.md
@@ -1,0 +1,9 @@
+---
+'gov4git-desktop-app': patch
+---
+
+Do not log logging activity
+
+- Previous versions logged logging activity
+  creating an explosion of data to be written to files
+  and degrading performance.

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -76,7 +76,9 @@ async function serviceHandler(
   try {
     const response = await services.invoke(invokeProps)
     logService.info(`Invoking ${invokeProps.service}:`, invokeProps)
-    logService.info('Response:', response)
+    if (invokeProps.service !== 'log') {
+      logService.info('Response:', response)
+    }
     return response
   } catch (ex) {
     try {


### PR DESCRIPTION
- Previous versions logged logging activity creating an explosion of data to be written to files and degrading performance.